### PR TITLE
Fixed Allow create test client with different credentials. Moved log SetFlags from init to constructor, otherwise it mess application log configuraions

### DIFF
--- a/testing.go
+++ b/testing.go
@@ -12,11 +12,18 @@ const (
 )
 
 func init() {
-	log.SetFlags(log.Llongfile)
 	rand.Seed(time.Now().Unix())
 }
 func NewTestClient() *Client {
+	log.SetFlags(log.Llongfile)
 	c := NewClient(TEST_API_LOGIN_ID, TEST_API_TRANSACTION_KEY)
+	c.url = SANDBOX_URL
+	return c
+}
+
+func NewTestClientWithCredentials(name, transactionKey string) *Client {
+	log.SetFlags(log.Llongfile)
+	c := NewClient(name, transactionKey)
 	c.url = SANDBOX_URL
 	return c
 }


### PR DESCRIPTION
Hi, i found it useful to be able provide my own credentials for test client.
